### PR TITLE
Feat/creat refinancing proposal

### DIFF
--- a/server/src/domain/models/apr/AprData.ts
+++ b/server/src/domain/models/apr/AprData.ts
@@ -1,0 +1,4 @@
+export interface AprData {
+  value: number
+  createdAt: Date
+}

--- a/server/src/domain/models/apr/IAprRepository.ts
+++ b/server/src/domain/models/apr/IAprRepository.ts
@@ -1,0 +1,6 @@
+import { AprData } from './AprData'
+
+export interface IAprRepository {
+  findLast: () => Promise<AprData | null>
+  add: (aprData: AprData) => Promise<void>
+}

--- a/server/src/domain/models/refinancingProposal/IRefinancingProposalRepository.ts
+++ b/server/src/domain/models/refinancingProposal/IRefinancingProposalRepository.ts
@@ -1,0 +1,6 @@
+import { RefinancingProposalData } from './RefinancingProposalData'
+
+export interface IRefinancingProposalRepository {
+  findByKey: (key: string) => Promise<RefinancingProposalData | null>
+  add: (RefinancingProposals: RefinancingProposalData) => Promise<void>
+}

--- a/server/src/domain/models/refinancingProposal/PaymentPlan.ts
+++ b/server/src/domain/models/refinancingProposal/PaymentPlan.ts
@@ -1,0 +1,25 @@
+import { Either, success, fail } from '@crosscutting/either'
+import { InvalidPaymentPlan } from '@domain/share/errors/InvalidPaymentPlan'
+import { PaymentPlanData } from './paymenPlanData'
+
+export class PaymentPlan {
+  public readonly valeu: number
+  public readonly months: number
+
+  private constructor (valeu: number, months: number) {
+    this.valeu = valeu
+    this.months = months
+
+    Object.freeze(this)
+  }
+
+  static create (paymentPlanData: PaymentPlanData): Either<InvalidPaymentPlan, PaymentPlan> {
+    const { value, months } = paymentPlanData
+
+    if (!months || !value || value <= 0) {
+      return fail(new InvalidPaymentPlan(value, months))
+    }
+
+    return success(new PaymentPlan(value, months))
+  }
+}

--- a/server/src/domain/models/refinancingProposal/PaymentPlan.ts
+++ b/server/src/domain/models/refinancingProposal/PaymentPlan.ts
@@ -3,11 +3,11 @@ import { InvalidPaymentPlan } from '@domain/share/errors/InvalidPaymentPlan'
 import { PaymentPlanData } from './paymenPlanData'
 
 export class PaymentPlan {
-  public readonly valeu: number
+  public readonly value: number
   public readonly months: number
 
-  private constructor (valeu: number, months: number) {
-    this.valeu = valeu
+  private constructor (value: number, months: number) {
+    this.value = value
     this.months = months
 
     Object.freeze(this)

--- a/server/src/domain/models/refinancingProposal/RefinancingProposal.ts
+++ b/server/src/domain/models/refinancingProposal/RefinancingProposal.ts
@@ -1,0 +1,70 @@
+import { Either, fail, success } from '@crosscutting/either'
+import { InvalidCarError } from '@domain/share/errors/InvalidCarError'
+import { InvalidCarBrandError } from '@domain/share/errors/InvalidCarBrandError'
+import { InvalidAPRError } from '@domain/share/errors/InvalidAPRError'
+import { PaymentPlan } from './PaymentPlan'
+import { InvalidPaymentPlan } from '@domain/share/errors/InvalidPaymentPlan'
+import { Entity } from '@domain/share/entity'
+import { CarBradProposal } from './carBrandProposal'
+import { CarProposal } from './carProposal'
+
+export class RefinancingProposal extends Entity {
+  public readonly proposalNumber: string
+  public readonly carBrand: CarBradProposal
+  public readonly car: CarProposal
+  public readonly apr: number
+  public readonly paymentOptions: PaymentPlan[]
+
+  private constructor (
+    proposalNumber: string,
+    carBrand: CarBradProposal,
+    car: CarProposal,
+    apr: number,
+    paymentOptions: PaymentPlan[]) {
+    super()
+    this.proposalNumber = proposalNumber
+    this.carBrand = carBrand
+    this.car = car
+    this.apr = apr
+    this.paymentOptions = paymentOptions
+    Object.freeze(this)
+  }
+
+  static create (carBrand: CarBradProposal, car: CarProposal, apr: number):
+    Either<InvalidCarError | InvalidCarBrandError | InvalidAPRError | InvalidPaymentPlan, RefinancingProposal> {
+    if (!carBrand || !carBrand.key) {
+      return fail(new InvalidCarBrandError('Missing car brand'))
+    }
+
+    if (!car || !car.key) {
+      return fail(new InvalidCarError(0))
+    }
+
+    if (!apr) {
+      return fail(new InvalidAPRError(apr))
+    }
+
+    const proposalNumber = `#${Date.now}`
+    const paymentOptionsOrErros = this.calculatePaymentPlan(car, apr)
+
+    const paymentOptionsError = paymentOptionsOrErros.find(item => item.Failed())
+    if (paymentOptionsError) {
+      return fail(paymentOptionsError.value as InvalidPaymentPlan)
+    }
+
+    const paymentOptions = paymentOptionsOrErros.map(item => item.value as PaymentPlan)
+    return success(new RefinancingProposal(proposalNumber, carBrand, car, apr, paymentOptions))
+  }
+
+  private static calculatePaymentPlan (car: CarProposal, apr: number): Either<InvalidPaymentPlan, PaymentPlan>[] {
+    const installments = [36, 48]
+    const monthsOfYaer = 12
+    const installmentCalculationOrError = installments.map(months => {
+      const { price: carPrice } = car
+      const totalValue = carPrice + (carPrice * (apr / 100) * (months / monthsOfYaer))
+      const monthlyValue = Number((totalValue / months).toFixed(2))
+      return PaymentPlan.create({ months, value: monthlyValue })
+    })
+    return installmentCalculationOrError.flatMap(item => item)
+  }
+}

--- a/server/src/domain/models/refinancingProposal/RefinancingProposal.ts
+++ b/server/src/domain/models/refinancingProposal/RefinancingProposal.ts
@@ -1,5 +1,4 @@
 import { Either, fail, success } from '@crosscutting/either'
-import { InvalidCarError } from '@domain/share/errors/InvalidCarError'
 import { InvalidCarBrandError } from '@domain/share/errors/InvalidCarBrandError'
 import { InvalidAPRError } from '@domain/share/errors/InvalidAPRError'
 import { PaymentPlan } from './PaymentPlan'
@@ -7,6 +6,7 @@ import { InvalidPaymentPlan } from '@domain/share/errors/InvalidPaymentPlan'
 import { Entity } from '@domain/share/entity'
 import { CarBradProposal } from './carBrandProposal'
 import { CarProposal } from './carProposal'
+import { InvalidCarProposalError } from '@domain/share/errors/InvalidCarProposalError'
 
 export class RefinancingProposal extends Entity {
   public readonly proposalNumber: string
@@ -31,20 +31,20 @@ export class RefinancingProposal extends Entity {
   }
 
   static create (carBrand: CarBradProposal, car: CarProposal, apr: number):
-    Either<InvalidCarError | InvalidCarBrandError | InvalidAPRError | InvalidPaymentPlan, RefinancingProposal> {
+    Either<InvalidCarProposalError | InvalidCarBrandError | InvalidAPRError | InvalidPaymentPlan, RefinancingProposal> {
     if (!carBrand || !carBrand.key) {
       return fail(new InvalidCarBrandError('Missing car brand'))
     }
 
     if (!car || !car.key) {
-      return fail(new InvalidCarError(0))
+      return fail(new InvalidCarProposalError('Missing car'))
     }
 
     if (!apr) {
       return fail(new InvalidAPRError(apr))
     }
 
-    const proposalNumber = `#${Date.now}`
+    const proposalNumber = `#${Date.now()}`
     const paymentOptionsOrErros = this.calculatePaymentPlan(car, apr)
 
     const paymentOptionsError = paymentOptionsOrErros.find(item => item.Failed())

--- a/server/src/domain/models/refinancingProposal/RefinancingProposalData.ts
+++ b/server/src/domain/models/refinancingProposal/RefinancingProposalData.ts
@@ -1,0 +1,16 @@
+import { CarBradProposal } from './carBrandProposal'
+import { CarProposal } from './carProposal'
+
+interface paymentOptionsData {
+  value: number
+  months: number
+}
+
+export interface RefinancingProposalData {
+  key: string
+  proposalNumber: string
+  carBrand: CarBradProposal
+  car: CarProposal
+  apr: number
+  paymentOptions: paymentOptionsData[]
+}

--- a/server/src/domain/models/refinancingProposal/carBrandProposal.ts
+++ b/server/src/domain/models/refinancingProposal/carBrandProposal.ts
@@ -1,0 +1,6 @@
+
+export interface CarBradProposal {
+  key: string
+  image: string
+  name: string
+}

--- a/server/src/domain/models/refinancingProposal/carProposal.ts
+++ b/server/src/domain/models/refinancingProposal/carProposal.ts
@@ -1,0 +1,6 @@
+export interface CarProposal {
+  key: string
+  name: string
+  image: string
+  price: number
+}

--- a/server/src/domain/models/refinancingProposal/paymenPlanData.ts
+++ b/server/src/domain/models/refinancingProposal/paymenPlanData.ts
@@ -1,0 +1,5 @@
+
+export interface PaymentPlanData {
+  value: number
+  months: number
+}

--- a/server/src/domain/share/errors/InvalidAPRError.ts
+++ b/server/src/domain/share/errors/InvalidAPRError.ts
@@ -1,0 +1,8 @@
+import { DomainError } from './domainError'
+
+export class InvalidAPRError extends Error implements DomainError {
+  constructor (value: number) {
+    super(`The APR "${value}" is invalid.`)
+    this.name = 'InvalidAPRError'
+  }
+}

--- a/server/src/domain/share/errors/InvalidCarProposalError.ts
+++ b/server/src/domain/share/errors/InvalidCarProposalError.ts
@@ -1,0 +1,8 @@
+import { DomainError } from './domainError'
+
+export class InvalidCarProposalError extends Error implements DomainError {
+  constructor (message: string) {
+    super(`The car is invalid. "${message}".`)
+    this.name = 'InvalidCarProposalError'
+  }
+}

--- a/server/src/domain/share/errors/InvalidPaymentPlan.ts
+++ b/server/src/domain/share/errors/InvalidPaymentPlan.ts
@@ -1,0 +1,8 @@
+import { DomainError } from './domainError'
+
+export class InvalidPaymentPlan extends Error implements DomainError {
+  constructor (value: number, months: number) {
+    super(`The payment, with value: ${value} and months: ${months} is invalid.`)
+    this.name = 'InvalidPaymentPlan'
+  }
+}

--- a/server/src/domain/share/errors/InvalidRefinancingProposalError.ts
+++ b/server/src/domain/share/errors/InvalidRefinancingProposalError.ts
@@ -1,0 +1,9 @@
+
+import { DomainError } from './domainError'
+
+export class InvalidRefinancingProposalError extends Error implements DomainError {
+  constructor (message: string) {
+    super(`The refinancing proposal is invalid. ${message}`)
+    this.name = 'InvalidRefinancingProposalError'
+  }
+}

--- a/server/src/domain/useCases/registerRefinancingProposal/RegisterRefinancingProposalResponse.ts
+++ b/server/src/domain/useCases/registerRefinancingProposal/RegisterRefinancingProposalResponse.ts
@@ -1,0 +1,5 @@
+import { Either } from '@crosscutting/either'
+import { InvalidRefinancingProposalError } from '@domain/share/errors/InvalidRefinancingProposalError'
+import { RefinancingProposalCreated } from './model'
+
+export type RegisterRefinancingProposalResponse = Either<InvalidRefinancingProposalError, RefinancingProposalCreated>

--- a/server/src/domain/useCases/registerRefinancingProposal/index.ts
+++ b/server/src/domain/useCases/registerRefinancingProposal/index.ts
@@ -1,17 +1,43 @@
+import { success, fail } from '@crosscutting/either'
+import { IAprRepository } from '@domain/models/apr/IAprRepository'
 import { ICarBrandRepository } from '@domain/models/carBrand/ICarBranRepository'
+import { IRefinancingProposalRepository } from '@domain/models/refinancingProposal/IRefinancingProposalRepository'
+import { RefinancingProposal } from '@domain/models/refinancingProposal/RefinancingProposal'
+import { InvalidRefinancingProposalError } from '@domain/share/errors/InvalidRefinancingProposalError'
 import { RefinancingProposalInput } from './model'
+import { RegisterRefinancingProposalResponse } from './RegisterRefinancingProposalResponse'
 
 export interface IRegisterRefinancingProposal {
-  execute: (refinancingProposalInput: RefinancingProposalInput) => Promise<void>
+  execute: (refinancingProposalInput: RefinancingProposalInput) => Promise<RegisterRefinancingProposalResponse>
 }
 
-function RegisterRefinancingProposal (carBrandRepository: ICarBrandRepository): IRegisterRefinancingProposal {
+function RegisterRefinancingProposal (
+  carBrandRepository: ICarBrandRepository,
+  aprRepository: IAprRepository,
+  refinancingProposalRepository: IRefinancingProposalRepository
+): IRegisterRefinancingProposal {
   const _carBrandRepository = carBrandRepository
+  const _aprRepository = aprRepository
+  const _refinancingProposalRepository = refinancingProposalRepository
   return {
     execute: async (refinancingProposalInput: RefinancingProposalInput) => {
-      const { carBrandKey } = refinancingProposalInput
+      const { carBrandKey, carKey } = refinancingProposalInput
       const carBrand = await _carBrandRepository.findByKey(carBrandKey)
-      console.log(carBrand)
+      const car = carBrand?.cars.find(item => item.key === carKey)
+      const apr = await _aprRepository.findLast() || { value: 0 }
+
+      const carBrandProposal = { key: carBrand?.key!, name: carBrand?.name!, image: carBrand?.image! }
+      const carProposal = { key: car?.key!, name: car?.name!, price: car?.price!, image: car?.image! }
+      const refinancingProposaOrError = RefinancingProposal.create(carBrandProposal, carProposal, apr.value)
+
+      if (refinancingProposaOrError.Failed()) {
+        return fail(new InvalidRefinancingProposalError((refinancingProposaOrError.value).message))
+      }
+
+      const refinancingProposa = refinancingProposaOrError.value
+      await _refinancingProposalRepository.add(refinancingProposa)
+
+      return success({ key: refinancingProposa.key })
     }
   }
 }

--- a/server/src/domain/useCases/registerRefinancingProposal/index.ts
+++ b/server/src/domain/useCases/registerRefinancingProposal/index.ts
@@ -1,0 +1,19 @@
+import { ICarBrandRepository } from '@domain/models/carBrand/ICarBranRepository'
+import { RefinancingProposalInput } from './model'
+
+export interface IRegisterRefinancingProposal {
+  execute: (refinancingProposalInput: RefinancingProposalInput) => Promise<void>
+}
+
+function RegisterRefinancingProposal (carBrandRepository: ICarBrandRepository): IRegisterRefinancingProposal {
+  const _carBrandRepository = carBrandRepository
+  return {
+    execute: async (refinancingProposalInput: RefinancingProposalInput) => {
+      const { carBrandKey } = refinancingProposalInput
+      const carBrand = await _carBrandRepository.findByKey(carBrandKey)
+      console.log(carBrand)
+    }
+  }
+}
+
+export default RegisterRefinancingProposal

--- a/server/src/domain/useCases/registerRefinancingProposal/model.ts
+++ b/server/src/domain/useCases/registerRefinancingProposal/model.ts
@@ -3,3 +3,7 @@ export interface RefinancingProposalInput {
   carBrandKey: string
   carKey: string
 }
+
+export interface RefinancingProposalCreated {
+  key: string
+}

--- a/server/src/domain/useCases/registerRefinancingProposal/model.ts
+++ b/server/src/domain/useCases/registerRefinancingProposal/model.ts
@@ -1,0 +1,5 @@
+
+export interface RefinancingProposalInput {
+  carBrandKey: string
+  carKey: string
+}

--- a/server/src/infra/data/inMemory/InMemoryAprRepository.ts
+++ b/server/src/infra/data/inMemory/InMemoryAprRepository.ts
@@ -1,0 +1,16 @@
+import { AprData } from '@domain/models/apr/AprData'
+import { IAprRepository } from '@domain/models/apr/IAprRepository'
+
+function InMemoryAprRepository (): IAprRepository {
+  const _aprs: AprData[] = []
+  return {
+    add: async function (aprData: AprData): Promise<void> {
+      _aprs.push(aprData)
+    },
+    findLast: async function () {
+      return _aprs.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())[0]
+    }
+  }
+}
+
+export default InMemoryAprRepository

--- a/server/src/infra/data/inMemory/InMemoryRefinancingProposalRepository.ts
+++ b/server/src/infra/data/inMemory/InMemoryRefinancingProposalRepository.ts
@@ -1,0 +1,17 @@
+import { IRefinancingProposalRepository } from '@domain/models/refinancingProposal/IRefinancingProposalRepository'
+import { RefinancingProposalData } from '@domain/models/refinancingProposal/RefinancingProposalData'
+
+function InMemoryRefinancingProposalRepository (): IRefinancingProposalRepository {
+  const _data: RefinancingProposalData[] = []
+  return {
+    add: async function (refinancingProposalData: RefinancingProposalData): Promise<void> {
+      _data.push({ ...refinancingProposalData })
+    },
+    findByKey: async function (key: string) {
+      const result = _data.find(item => item.key === key)
+      return result || null
+    }
+  }
+}
+
+export default InMemoryRefinancingProposalRepository

--- a/server/src/infra/data/mongo/AprRepository.ts
+++ b/server/src/infra/data/mongo/AprRepository.ts
@@ -1,0 +1,21 @@
+import { AprData } from '@domain/models/apr/AprData'
+import { IAprRepository } from '@domain/models/apr/IAprRepository'
+import { MongoHelper } from './base'
+
+function AprRepository (): IAprRepository {
+  async function getCollection () {
+    return (await MongoHelper.getCollection('aprs'))
+  }
+  return {
+    add: async function (aprData: AprData): Promise<void> {
+      const aprCollection = await getCollection()
+      await aprCollection.insertOne({ ...aprData })
+    },
+    findLast: async function () {
+      const aprCollection = await getCollection()
+      return (await aprCollection.find().sort({ createdAt: -1 }).next())
+    }
+  }
+}
+
+export default AprRepository

--- a/server/src/infra/data/mongo/RefinancingProposalRepository.ts
+++ b/server/src/infra/data/mongo/RefinancingProposalRepository.ts
@@ -1,0 +1,22 @@
+import { IRefinancingProposalRepository } from '@domain/models/refinancingProposal/IRefinancingProposalRepository'
+import { RefinancingProposalData } from '@domain/models/refinancingProposal/RefinancingProposalData'
+import { MongoHelper } from './base'
+
+function RefinancingProposalRepository (): IRefinancingProposalRepository {
+  async function getCollection () {
+    return (await MongoHelper.getCollection('refinancingProposals'))
+  }
+  return {
+    add: async function (refinancingProposalData: RefinancingProposalData): Promise<void> {
+      const refinancingProposaCollection = await getCollection()
+      await refinancingProposaCollection.insertOne({ ...refinancingProposalData })
+    },
+    findByKey: async function (key: string) {
+      const refinancingProposaCollection = await getCollection()
+      const result = await refinancingProposaCollection.findOne({ key })
+      return result
+    }
+  }
+}
+
+export default RefinancingProposalRepository

--- a/server/src/main/api/index.ts
+++ b/server/src/main/api/index.ts
@@ -3,7 +3,8 @@ import cors from 'cors'
 import setupRoutest from './setupRoutest'
 
 const app = express()
-app.use(cors())
+
 app.use(express.json())
+app.use(cors({ origin: '*' }))
 setupRoutest(app)
 export default app

--- a/server/src/main/api/routes/refinancingProposal.route.ts
+++ b/server/src/main/api/routes/refinancingProposal.route.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express'
+import { createRefinancingProposalController } from '../../factories/refinancingProposal'
+import { adaptRoute } from '../../adapters/routesAdapter'
+
+export default (router: Router): void => {
+  router.post('/proposals', adaptRoute(createRefinancingProposalController()))
+}

--- a/server/src/main/factories/refinancingProposal.ts
+++ b/server/src/main/factories/refinancingProposal.ts
@@ -1,0 +1,19 @@
+import RegisterRefinancingProposal from '@domain/useCases/registerRefinancingProposal'
+import AprRepository from '@infra/data/mongo/AprRepository'
+import CarBrandRepository from '@infra/data/mongo/CarBrandRepository'
+import RefinancingProposalRepository from '@infra/data/mongo/RefinancingProposalRepository'
+import RefinancingProposalController from '@presentation/controllers/proposal/saveRefinancingProposalController'
+
+export const createRefinancingProposalController = () => {
+  const carBrandRepository = CarBrandRepository()
+  const aprRepository = AprRepository()
+  const refinancingProposalRepository = RefinancingProposalRepository()
+
+  const registerRefinancingProposalUseCase = RegisterRefinancingProposal(
+    carBrandRepository,
+    aprRepository,
+    refinancingProposalRepository)
+
+  const refinancingProposalController = RefinancingProposalController(registerRefinancingProposalUseCase)
+  return refinancingProposalController
+}

--- a/server/src/presentation/controllers/proposal/saveRefinancingProposalController.ts
+++ b/server/src/presentation/controllers/proposal/saveRefinancingProposalController.ts
@@ -1,0 +1,22 @@
+import { Controller } from '@presentation/base/controller'
+import { InvalidParamError } from '@presentation/base/errors/invalidParamError'
+import { badRequest, HttpRequest, HttpResponse, ok, serverError } from '@presentation/base/https'
+
+function RefinancingProposalController (): Controller {
+  return {
+    handle: async function (httpRequest: HttpRequest): Promise<HttpResponse> {
+      try {
+        const { carBrandId, carName } = httpRequest.body
+        if (carBrandId || carName) {
+          const field = !carBrandId ? 'carBrandId' : 'carName'
+          return badRequest(new InvalidParamError(field))
+        }
+        return ok({})
+      } catch (error) {
+        return serverError(error)
+      }
+    }
+  }
+}
+
+export default RefinancingProposalController

--- a/server/src/presentation/controllers/proposal/saveRefinancingProposalController.ts
+++ b/server/src/presentation/controllers/proposal/saveRefinancingProposalController.ts
@@ -1,17 +1,23 @@
+import { IRegisterRefinancingProposal } from '@domain/useCases/registerRefinancingProposal'
 import { Controller } from '@presentation/base/controller'
 import { InvalidParamError } from '@presentation/base/errors/invalidParamError'
 import { badRequest, HttpRequest, HttpResponse, ok, serverError } from '@presentation/base/https'
 
-function RefinancingProposalController (): Controller {
+function RefinancingProposalController (registerRefinancingProposal: IRegisterRefinancingProposal): Controller {
+  const _registerRefinancingProposal = registerRefinancingProposal
   return {
     handle: async function (httpRequest: HttpRequest): Promise<HttpResponse> {
       try {
-        const { carBrandId, carName } = httpRequest.body
-        if (carBrandId || carName) {
-          const field = !carBrandId ? 'carBrandId' : 'carName'
+        const { carBrandKey, carKey } = httpRequest.body
+        if (!carBrandKey || !carKey) {
+          const field = !carBrandKey ? 'carBrandKey' : 'carKey'
           return badRequest(new InvalidParamError(field))
         }
-        return ok({})
+        const refinancingProposalResponseOrError = await _registerRefinancingProposal.execute({ carBrandKey, carKey })
+        if (refinancingProposalResponseOrError.Failed()) {
+          return badRequest(refinancingProposalResponseOrError.value)
+        }
+        return ok(refinancingProposalResponseOrError.value)
       } catch (error) {
         return serverError(error)
       }

--- a/server/tests/__integration__/refinancingProposal.api.test.ts
+++ b/server/tests/__integration__/refinancingProposal.api.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest'
+import app from '../../src/main/api'
+import CarBrandRepository from '../../src/infra/data/mongo/CarBrandRepository'
+import AprRepository from '../../src/infra/data/mongo/AprRepository'
+import { MongoHelper } from '../../src/infra/data/mongo/base'
+
+import carbrandsMock from '../__mocks__/carbrands.json'
+
+describe('Refinancing Proposal Routes', () => {
+  beforeAll(async () => {
+    const MONGO_URL = process.env.MONGO_URL || ''
+    await MongoHelper.connect(MONGO_URL)
+    const carBrandRepository = CarBrandRepository()
+    await carBrandRepository.addMany(carbrandsMock)
+
+    const aprRepository = AprRepository()
+    await aprRepository.add({ value: 5, createdAt: new Date('2021-03-01T22:50:39.228Z') })
+  })
+
+  afterAll(async () => {
+    await MongoHelper.disconnect()
+  })
+
+  test('should return 404 if carBrandKey is invalid', async () => {
+    const body = {
+      carBrandKey: 'invalid',
+      carKey: 'invalid'
+    }
+    const result = await request(app)
+      .post('/api/proposals')
+      .send(body)
+
+    expect(result.status).toBe(400)
+  })
+
+  test('should return 200 if all data is correct', async () => {
+    const carBrand = carbrandsMock[0]
+    const body = {
+      carBrandKey: carBrand.key,
+      carKey: carBrand.cars[0].key
+    }
+    const result = await request(app)
+      .post('/api/proposals')
+      .send(body)
+
+    expect(result.status).toBe(200)
+  })
+})

--- a/server/tests/__mocks__/carbrands.json
+++ b/server/tests/__mocks__/carbrands.json
@@ -1,112 +1,50 @@
 [
   {
-    "key": "wer23234-234234234",
-    "name": "Subaru",
-    "image": "https://static.wixstatic.com/media/b00f6a_a56dcfd7fb9d48caa0d2c1dffab0ce94~mv2.png",
+    "key": "0a06e733-a952-467e-850b-5e1e1f8c38c3",
+    "createdAt": "2021-03-27T22:50:39.229Z",
+    "updatedAt": "2021-03-27T22:50:39.229Z",
+    "name": "Acura",
+    "image": "https://static.wixstatic.com/media/b00f6a_33d9b2dc534d415fafc24a9af26bdc85~mv2.png",
     "cars": [
       {
-        "key": "wer23234-234234232",
-        "name": "Subaru Ascent 2020",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/30160.jpg",
-        "price": 41377
+        "key": "fecfe64c-307c-4d20-9e57-7ebce9b8fe1d",
+        "createdAt": "2021-03-27T22:50:39.228Z",
+        "updatedAt": "2021-03-27T22:50:39.228Z",
+        "name": "Acura ILX 2019",
+        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/30821.jpg",
+        "price": 23416
       },
       {
-        "key": "wer23234-234234qww4",
-        "name": "Subaru Crosstrek 2020",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/31118.jpg",
-        "price": 24348
+        "key": "b3beacfa-dee8-49dc-861e-5396dda369c0",
+        "createdAt": "2021-03-27T22:50:39.228Z",
+        "updatedAt": "2021-03-27T22:50:39.228Z",
+        "name": "Acura MDX Sport Hybrid 2017",
+        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/27683.jpg",
+        "price": 37809
       },
       {
-        "key": "wer23234-234vbgyw4",
-        "name": "Subaru Impreza 2020",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/31077.jpg",
-        "price": 23382
+        "key": "0b1d0f68-092f-44f3-8aee-a90e5de57e72",
+        "createdAt": "2021-03-27T22:50:39.228Z",
+        "updatedAt": "2021-03-27T22:50:39.228Z",
+        "name": "Acura RDX 2020",
+        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/30173.jpg",
+        "price": 39318
       },
       {
-        "key": "wer23234-234a34314",
-        "name": "Subaru Outback 2020",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/30628.jpg",
-        "price": 28882
+        "key": "66cfe758-62b5-42e0-8565-5d3247193574",
+        "createdAt": "2021-03-27T22:50:39.228Z",
+        "updatedAt": "2021-03-27T22:50:39.228Z",
+        "name": "Acura RLX 2018",
+        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/30681.jpg",
+        "price": 33723
       },
       {
-        "key": "wer23234-2988844",
-        "name": "Subaru WRX 2020",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/30773.jpg",
-        "price": 29653
-      }
-    ]
-  },
-  {
-    "key": "pojyewe-rjeerrty",
-    "name": "Fiat",
-    "image": "https://static.wixstatic.com/media/b00f6a_0965ff410b29461abcf6e56f96c10fbb~mv2.png",
-    "cars": [
-      {
-        "key": "pojyewe-rjee234",
-        "name": "FIAT 124 Spider 2019",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/28168.jpg",
-        "price": 25981
-      },
-      {
-        "key": "pojyewe-rjeerr3432",
-        "name": "FIAT 500 Abarth 2018",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/28233.jpg",
-        "price": 0
-      },
-      {
-        "key": "pojyewe-rjepkjhhg",
-        "name": "FIAT 500X 2018",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/27523.jpg",
-        "price": 13140
-      },
-      {
-        "key": "pojyewe-rje7gbww",
-        "name": "FIAT 500e 2017",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/24812.jpg",
-        "price": 7491
-      },
-      {
-        "key": "pojyewe-363gejf8",
-        "name": "FIAT 500 2018",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/29744.jpg",
-        "price": 15092
-      }
-    ]
-  },
-  {
-    "key": "73tgsdf-sknsdjf",
-    "name": "Mitsubishi",
-    "image": "https://static.wixstatic.com/media/b00f6a_6b8435c42b1f4506adf577c8aee20359~mv2.png",
-    "cars": [
-      {
-        "key": "73tgsdf-wer4uhri",
-        "name": "Mitsubishi Eclipse 2012",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/13735.jpg",
-        "price": 12251
-      },
-      {
-        "key": "73tgsdf-f3rt34r",
-        "name": "Mitsubishi Endeavor 2008",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/10772.jpg",
-        "price": 5402
-      },
-      {
-        "key": "73tgsdf-psideur",
-        "name": "Mitsubishi Lancer 2017",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/24505.jpg",
-        "price": 11587
-      },
-      {
-        "key": "73tgsdf-dwkwkd",
-        "name": "Mitsubishi Mirage G4 2019",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/28922.jpg",
-        "price": 10953
-      },
-      {
-        "key": "73tgsdf-eu2erhbfw",
-        "name": "Mitsubishi Outlander PHEV 2018",
-        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/28286.jpg",
-        "price": 24462
+        "key": "5bffa365-e3cf-4ca9-9654-b0be4356245c",
+        "createdAt": "2021-03-27T22:50:39.228Z",
+        "updatedAt": "2021-03-27T22:50:39.228Z",
+        "name": "Acura TLX 2020",
+        "image": "http://media.chromedata.com/autoBuilderData/stockPhotos/31312.jpg",
+        "price": 28327
       }
     ]
   }

--- a/server/tests/domain/model/paymentPlan.spec.ts
+++ b/server/tests/domain/model/paymentPlan.spec.ts
@@ -1,0 +1,33 @@
+import { PaymentPlan } from '../../../src/domain/models/refinancingProposal/PaymentPlan'
+import { InvalidPaymentPlan } from '../../../src/domain/share/errors/InvalidPaymentPlan'
+import { fail } from '../../../src/crosscutting/either'
+
+describe('PaymentPlan', () => {
+  test('Should not create PaymentPlan with invalida value', () => {
+    const value = -550
+    const months = 36
+
+    const paymentPlanOrError = PaymentPlan.create({ value, months })
+
+    expect(paymentPlanOrError).toEqual(fail(new InvalidPaymentPlan(value, months)))
+  })
+
+  test('Should not create PaymentPlan with invalida months', () => {
+    const value = 340
+    const months = 0
+
+    const paymentPlanOrError = PaymentPlan.create({ value, months })
+
+    expect(paymentPlanOrError).toEqual(fail(new InvalidPaymentPlan(value, months)))
+  })
+
+  test('Should create paymentPlan when all correct data', () => {
+    const value = 340
+    const months = 36
+
+    const paymentPlanOrError = PaymentPlan.create({ value, months })
+    const paymentPlan = paymentPlanOrError.value as PaymentPlan
+    expect(paymentPlan.months).toBe(months)
+    expect(paymentPlan.valeu).toBe(value)
+  })
+})

--- a/server/tests/domain/model/paymentPlan.spec.ts
+++ b/server/tests/domain/model/paymentPlan.spec.ts
@@ -28,6 +28,6 @@ describe('PaymentPlan', () => {
     const paymentPlanOrError = PaymentPlan.create({ value, months })
     const paymentPlan = paymentPlanOrError.value as PaymentPlan
     expect(paymentPlan.months).toBe(months)
-    expect(paymentPlan.valeu).toBe(value)
+    expect(paymentPlan.value).toBe(value)
   })
 })

--- a/server/tests/domain/model/refinancingProposal.spec.ts
+++ b/server/tests/domain/model/refinancingProposal.spec.ts
@@ -1,0 +1,88 @@
+import { RefinancingProposal } from '../../../src/domain/models/refinancingProposal/RefinancingProposal'
+import { InvalidCarBrandError } from '../../../src/domain/share/errors/InvalidCarBrandError'
+import { InvalidPaymentPlan } from '../../../src/domain/share/errors/InvalidPaymentPlan'
+import { InvalidAPRError } from '../../../src/domain/share/errors/InvalidAPRError'
+import { InvalidCarError } from '../../../src/domain/share/errors/InvalidCarError'
+import { fail } from '../../../src/crosscutting/either'
+
+const InvalidCarBrandProposal = {
+  key: '',
+  name: '',
+  image: ''
+}
+
+const InvalidCarProposal = {
+  key: '',
+  name: '',
+  image: '',
+  price: 0
+}
+
+const InvalidPriceCarProposal = {
+  key: 'fecfe64c-307c-4d20-9e57-7ebce9b8fe1d',
+  name: 'Acura ILX 2019',
+  image: 'image.png',
+  price: 0
+}
+
+const CarBrandProposal = {
+  key: 'key-car-brandacura',
+  name: 'Acura',
+  image: 'image.png'
+}
+
+const CarProposal = {
+  key: 'fecfe64c-307c-4d20-9e57-7ebce9b8fe1d',
+  name: 'Acura ILX 2019',
+  image: 'image.png',
+  price: 23416
+}
+
+describe('RefinancingProposal', () => {
+  test('Should not create RefinancingProposal with invalida carBrand', () => {
+    const apr = 10
+    const refinancingProposalOrError = RefinancingProposal.create(InvalidCarBrandProposal, CarProposal, apr)
+    expect(refinancingProposalOrError).toEqual(fail(new InvalidCarBrandError('Missing car brand')))
+  })
+
+  test('Should not create RefinancingProposal with invalida car', () => {
+    const apr = 10
+    const refinancingProposalOrError = RefinancingProposal.create(CarBrandProposal, InvalidCarProposal, apr)
+    expect(refinancingProposalOrError).toEqual(fail(new InvalidCarError(0)))
+  })
+
+  test('Should not create RefinancingProposal with invalida APR', () => {
+    const apr = 0
+    const refinancingProposalOrError = RefinancingProposal.create(CarBrandProposal, CarProposal, apr)
+    expect(refinancingProposalOrError).toEqual(fail(new InvalidAPRError(apr)))
+  })
+
+  test('Should not create RefinancingProposal with invalida payment plan', () => {
+    const apr = 10
+    const refinancingProposalOrError = RefinancingProposal.create(CarBrandProposal, InvalidPriceCarProposal, apr)
+    const resultError = refinancingProposalOrError.value as InvalidPaymentPlan
+    expect(resultError.message).toMatch(/The payment, with value: 0 and months: 36 is invalid./)
+    expect(resultError).toBeInstanceOf(InvalidPaymentPlan)
+  })
+
+  test('Should create RefinancingProposal when all correct data', () => {
+    const apr = 10
+    const refinancingProposalOrError = RefinancingProposal.create(CarBrandProposal, CarProposal, apr)
+    const resutl = refinancingProposalOrError.value as RefinancingProposal
+
+    expect(resutl.proposalNumber).not.toBe(null)
+    expect(resutl.carBrand.key).toBe(CarBrandProposal.key)
+    expect(resutl.carBrand.name).toBe(CarBrandProposal.name)
+    expect(resutl.car.key).toBe(CarProposal.key)
+    expect(resutl.car.name).toBe(CarProposal.name)
+    expect(resutl.apr).toBe(apr)
+    expect(resutl.paymentOptions.length).toBe(2)
+    expect(resutl.paymentOptions)
+      .toEqual(expect
+        .arrayContaining([
+          expect.objectContaining({ valeu: 845.58, months: 36 }),
+          expect.objectContaining({ valeu: 682.97, months: 48 })
+        ])
+      )
+  })
+})

--- a/server/tests/domain/model/refinancingProposal.spec.ts
+++ b/server/tests/domain/model/refinancingProposal.spec.ts
@@ -2,7 +2,7 @@ import { RefinancingProposal } from '../../../src/domain/models/refinancingPropo
 import { InvalidCarBrandError } from '../../../src/domain/share/errors/InvalidCarBrandError'
 import { InvalidPaymentPlan } from '../../../src/domain/share/errors/InvalidPaymentPlan'
 import { InvalidAPRError } from '../../../src/domain/share/errors/InvalidAPRError'
-import { InvalidCarError } from '../../../src/domain/share/errors/InvalidCarError'
+import { InvalidCarProposalError } from '../../../src/domain/share/errors/InvalidCarProposalError'
 import { fail } from '../../../src/crosscutting/either'
 
 const InvalidCarBrandProposal = {
@@ -48,7 +48,7 @@ describe('RefinancingProposal', () => {
   test('Should not create RefinancingProposal with invalida car', () => {
     const apr = 10
     const refinancingProposalOrError = RefinancingProposal.create(CarBrandProposal, InvalidCarProposal, apr)
-    expect(refinancingProposalOrError).toEqual(fail(new InvalidCarError(0)))
+    expect((refinancingProposalOrError.value as InvalidCarProposalError).message).toMatch(/Missing car./)
   })
 
   test('Should not create RefinancingProposal with invalida APR', () => {
@@ -80,8 +80,8 @@ describe('RefinancingProposal', () => {
     expect(resutl.paymentOptions)
       .toEqual(expect
         .arrayContaining([
-          expect.objectContaining({ valeu: 845.58, months: 36 }),
-          expect.objectContaining({ valeu: 682.97, months: 48 })
+          expect.objectContaining({ value: 845.58, months: 36 }),
+          expect.objectContaining({ value: 682.97, months: 48 })
         ])
       )
   })

--- a/server/tests/domain/useCases/registerRefinancingProposal.spec.ts
+++ b/server/tests/domain/useCases/registerRefinancingProposal.spec.ts
@@ -1,0 +1,36 @@
+import { ICarBrandRepository } from '../../../src/domain/models/carBrand/ICarBranRepository'
+import RegisterRefinancingProposal, { IRegisterRefinancingProposal } from '../../../src/domain/useCases/registerRefinancingProposal'
+import { RefinancingProposalInput } from '../../../src/domain/useCases/registerRefinancingProposal/model'
+import InMemoryIarBrandRepository from '../../../src/infra/data/inMemory/InMemoryCarBrandRepository'
+
+import carBrandMock from '../../__mocks__/carbrands.json'
+
+type SutTypes = {
+  sut: IRegisterRefinancingProposal
+  carBrandRepository: ICarBrandRepository
+}
+const makeSut = (): SutTypes => {
+  const carBrandRepository = InMemoryIarBrandRepository()
+  const sut = RegisterRefinancingProposal(carBrandRepository)
+
+  return { sut, carBrandRepository }
+}
+
+const makeRefinancingProposalInputSuccess = (): RefinancingProposalInput => {
+  return {
+    carBrandKey: carBrandMock[0].key,
+    carKey: carBrandMock[0].cars[0].key
+  }
+}
+
+describe('RegisterRefinancingProposal', () => {
+  test('Should call ICarBrandRepository with correct values', async () => {
+    const { sut, carBrandRepository } = makeSut()
+
+    const carBrandRepositorySpy = jest.spyOn(carBrandRepository, 'findByKey')
+    const refinancingProposalInput = makeRefinancingProposalInputSuccess()
+    await sut.execute(refinancingProposalInput)
+
+    expect(carBrandRepositorySpy).toHaveBeenCalledWith(refinancingProposalInput.carBrandKey)
+  })
+})

--- a/server/tests/domain/useCases/registerRefinancingProposal.spec.ts
+++ b/server/tests/domain/useCases/registerRefinancingProposal.spec.ts
@@ -1,19 +1,30 @@
 import { ICarBrandRepository } from '../../../src/domain/models/carBrand/ICarBranRepository'
+import { IAprRepository } from '../../../src/domain/models/apr/IAprRepository'
+import { IRefinancingProposalRepository } from '../../../src/domain/models/refinancingProposal/IRefinancingProposalRepository'
 import RegisterRefinancingProposal, { IRegisterRefinancingProposal } from '../../../src/domain/useCases/registerRefinancingProposal'
-import { RefinancingProposalInput } from '../../../src/domain/useCases/registerRefinancingProposal/model'
-import InMemoryIarBrandRepository from '../../../src/infra/data/inMemory/InMemoryCarBrandRepository'
+import { RefinancingProposalCreated, RefinancingProposalInput } from '../../../src/domain/useCases/registerRefinancingProposal/model'
+import InMemoryCarBrandRepository from '../../../src/infra/data/inMemory/InMemoryCarBrandRepository'
+import InMemoryAprRepository from '../../../src/infra/data/inMemory/InMemoryAprRepository'
+import InMemoryRefinancingProposalRepository from '../../../src/infra/data/inMemory/InMemoryRefinancingProposalRepository'
 
 import carBrandMock from '../../__mocks__/carbrands.json'
+import { RegisterRefinancingProposalResponse } from '../../../src/domain/useCases/registerRefinancingProposal/RegisterRefinancingProposalResponse'
+import { InvalidCarProposalError } from '../../../src/domain/share/errors/InvalidCarProposalError'
+import { InvalidRefinancingProposalError } from '../../../src/domain/share/errors/InvalidRefinancingProposalError'
+
+const carBrandRepository: ICarBrandRepository = InMemoryCarBrandRepository()
+const aprRepository: IAprRepository = InMemoryAprRepository()
+const refinancingProposalRepository = InMemoryRefinancingProposalRepository()
 
 type SutTypes = {
   sut: IRegisterRefinancingProposal
   carBrandRepository: ICarBrandRepository
+  aprRepository: IAprRepository
+  refinancingProposalRepository: IRefinancingProposalRepository
 }
 const makeSut = (): SutTypes => {
-  const carBrandRepository = InMemoryIarBrandRepository()
-  const sut = RegisterRefinancingProposal(carBrandRepository)
-
-  return { sut, carBrandRepository }
+  const sut = RegisterRefinancingProposal(carBrandRepository, aprRepository, refinancingProposalRepository)
+  return { sut, carBrandRepository, aprRepository, refinancingProposalRepository }
 }
 
 const makeRefinancingProposalInputSuccess = (): RefinancingProposalInput => {
@@ -22,6 +33,26 @@ const makeRefinancingProposalInputSuccess = (): RefinancingProposalInput => {
     carKey: carBrandMock[0].cars[0].key
   }
 }
+
+const makeRefinancingProposalInputCarBandFail = (): RefinancingProposalInput => {
+  return {
+    carBrandKey: 'fail',
+    carKey: carBrandMock[0].cars[0].key
+  }
+}
+
+const makeRefinancingProposalInputCarFail = (): RefinancingProposalInput => {
+  return {
+    carBrandKey: carBrandMock[0].key,
+    carKey: 'fail'
+  }
+}
+
+beforeAll(async () => {
+  await carBrandRepository.addMany(carBrandMock)
+  await aprRepository.add({ value: 5, createdAt: new Date('2021-03-01T22:50:39.228Z') })
+  await aprRepository.add({ value: 10, createdAt: new Date('2021-03-29T22:50:39.228Z') })
+})
 
 describe('RegisterRefinancingProposal', () => {
   test('Should call ICarBrandRepository with correct values', async () => {
@@ -32,5 +63,69 @@ describe('RegisterRefinancingProposal', () => {
     await sut.execute(refinancingProposalInput)
 
     expect(carBrandRepositorySpy).toHaveBeenCalledWith(refinancingProposalInput.carBrandKey)
+  })
+
+  test('Should call findLast of IAprRepository', async () => {
+    const { sut, aprRepository } = makeSut()
+
+    const aprRepositorySpy = jest.spyOn(aprRepository, 'findLast')
+    const refinancingProposalInput = makeRefinancingProposalInputSuccess()
+    await sut.execute(refinancingProposalInput)
+
+    expect(aprRepositorySpy).toHaveBeenCalled()
+  })
+
+  test('Should not create a RefinancingProposal with invalid CarrBrand', async () => {
+    const { sut } = makeSut()
+
+    const refinancingProposalInput = makeRefinancingProposalInputCarBandFail()
+    const refinancingProposalOrError: RegisterRefinancingProposalResponse = await sut.execute(refinancingProposalInput)
+
+    expect(refinancingProposalOrError.Failed()).toBe(true)
+    expect((refinancingProposalOrError.value as InvalidRefinancingProposalError).message).toMatch(/Missing car brand/)
+  })
+
+  test('Should not create a RefinancingProposal with invalid Carr', async () => {
+    const { sut } = makeSut()
+
+    const refinancingProposalInput = makeRefinancingProposalInputCarFail()
+    const refinancingProposalOrError: RegisterRefinancingProposalResponse = await sut.execute(refinancingProposalInput)
+
+    expect(refinancingProposalOrError.Failed()).toBe(true)
+    expect((refinancingProposalOrError.value as InvalidCarProposalError).message).toMatch(/Missing car./)
+  })
+
+  test('Should not create a RefinancingProposal with invalid APR', async () => {
+    const { sut, aprRepository } = makeSut()
+
+    jest.spyOn(aprRepository, 'findLast').mockReturnValueOnce(Promise.resolve({ value: 0, createdAt: new Date() }))
+
+    const refinancingProposalInput = makeRefinancingProposalInputSuccess()
+    const refinancingProposalOrError: RegisterRefinancingProposalResponse = await sut.execute(refinancingProposalInput)
+
+    expect(refinancingProposalOrError.Failed()).toBe(true)
+    expect(refinancingProposalOrError.Fulfilled()).toBe(false)
+    expect((refinancingProposalOrError.value as InvalidRefinancingProposalError).message).toMatch(/The APR "0" is invalid./)
+  })
+
+  test('Should create a RefinancingProposal when all data is correct', async () => {
+    const { sut, refinancingProposalRepository, aprRepository } = makeSut()
+
+    const refinancingProposalInput = makeRefinancingProposalInputSuccess()
+    const refinancingProposalOrError: RegisterRefinancingProposalResponse = await sut.execute(refinancingProposalInput)
+
+    expect(refinancingProposalOrError.Fulfilled()).toBe(true)
+    const proposalKey = (refinancingProposalOrError.value as RefinancingProposalCreated).key
+    expect(proposalKey).not.toBeNull()
+
+    const refinancingProposal = await refinancingProposalRepository.findByKey(proposalKey)
+    const apr = await aprRepository.findLast()
+
+    expect(refinancingProposal?.key).toBe(proposalKey)
+    expect(refinancingProposal?.carBrand.key).toBe(refinancingProposalInput.carBrandKey)
+    expect(refinancingProposal?.car.key).toBe(refinancingProposalInput.carKey)
+    expect(refinancingProposal?.proposalNumber).not.toBeNull()
+    expect(refinancingProposal?.apr).toBe(apr?.value)
+    expect(refinancingProposal?.paymentOptions.length).toBe(2)
   })
 })

--- a/server/tests/presentation/controllers/saveRefinancingProposalController.spec.ts
+++ b/server/tests/presentation/controllers/saveRefinancingProposalController.spec.ts
@@ -1,0 +1,37 @@
+import RefinancingProposalController from '../../../src/presentation/controllers/proposal/saveRefinancingProposalController'
+import { Controller } from '../../../src/presentation/base/controller'
+
+interface SutType {
+  sut: Controller
+}
+
+const makeSut = (): SutType => {
+  const sut = RefinancingProposalController()
+  return { sut }
+}
+
+describe('SaveProposal Controller', () => {
+  test('Should return 400 if no carBrandId is provided', async () => {
+    const { sut } = makeSut()
+    const httpRequest = {
+      body: {
+        carBrandId: '',
+        carName: 'carBrandId'
+      }
+    }
+    const result = await sut.handle(httpRequest)
+    expect(result.statusCode).toBe(400)
+  })
+
+  test('Should return 400 if no carName is provided', async () => {
+    const { sut } = makeSut()
+    const httpRequest = {
+      body: {
+        carBrandId: 'carBrandId',
+        carName: ''
+      }
+    }
+    const result = await sut.handle(httpRequest)
+    expect(result.statusCode).toBe(400)
+  })
+})

--- a/server/tests/presentation/controllers/saveRefinancingProposalController.spec.ts
+++ b/server/tests/presentation/controllers/saveRefinancingProposalController.spec.ts
@@ -1,37 +1,83 @@
 import RefinancingProposalController from '../../../src/presentation/controllers/proposal/saveRefinancingProposalController'
 import { Controller } from '../../../src/presentation/base/controller'
+import { ICarBrandRepository } from '../../../src/domain/models/carBrand/ICarBranRepository'
+import InMemoryCarBrandRepository from '../../../src/infra/data/inMemory/InMemoryCarBrandRepository'
+import { IAprRepository } from '../../../src/domain/models/apr/IAprRepository'
+import InMemoryAprRepository from '../../../src/infra/data/inMemory/InMemoryAprRepository'
+import InMemoryRefinancingProposalRepository from '../../../src/infra/data/inMemory/InMemoryRefinancingProposalRepository'
+import carBrandMock from '../../__mocks__/carbrands.json'
+import RegisterRefinancingProposal from '../../../src/domain/useCases/registerRefinancingProposal'
+
+const carBrandRepository: ICarBrandRepository = InMemoryCarBrandRepository()
+const aprRepository: IAprRepository = InMemoryAprRepository()
+const refinancingProposalRepository = InMemoryRefinancingProposalRepository()
 
 interface SutType {
   sut: Controller
 }
 
 const makeSut = (): SutType => {
-  const sut = RefinancingProposalController()
+  const registerRefinancingProposalUseCase = RegisterRefinancingProposal(carBrandRepository, aprRepository, refinancingProposalRepository)
+  const sut = RefinancingProposalController(registerRefinancingProposalUseCase)
   return { sut }
 }
 
+beforeAll(async () => {
+  await carBrandRepository.addMany(carBrandMock)
+  await aprRepository.add({ value: 5, createdAt: new Date('2021-03-01T22:50:39.228Z') })
+  await aprRepository.add({ value: 10, createdAt: new Date('2021-03-29T22:50:39.228Z') })
+})
+
 describe('SaveProposal Controller', () => {
-  test('Should return 400 if no carBrandId is provided', async () => {
+  test('Should return 400 if no carBrandKey is provided', async () => {
     const { sut } = makeSut()
     const httpRequest = {
       body: {
-        carBrandId: '',
-        carName: 'carBrandId'
+        carBrandKey: '',
+        carKey: 'carKey'
       }
     }
     const result = await sut.handle(httpRequest)
     expect(result.statusCode).toBe(400)
   })
 
-  test('Should return 400 if no carName is provided', async () => {
+  test('Should return 400 if no carKey is provided', async () => {
     const { sut } = makeSut()
     const httpRequest = {
       body: {
-        carBrandId: 'carBrandId',
-        carName: ''
+        carBrandKey: 'carBrandKey',
+        carKey: ''
       }
     }
     const result = await sut.handle(httpRequest)
     expect(result.statusCode).toBe(400)
+  })
+
+  test('Should return 400 if carKey provided is invalid', async () => {
+    const { sut } = makeSut()
+    const httpRequest = {
+      body: {
+        carBrandKey: 'carBrandKey-invalid',
+        carKey: 'carBrandKey'
+      }
+    }
+    const result = await sut.handle(httpRequest)
+    expect(result.statusCode).toBe(400)
+    expect(result.body.message).toMatch(/Missing car brand/)
+  })
+
+  test('Should return 200 if all data are correct', async () => {
+    const { sut } = makeSut()
+    const carBrand = carBrandMock[0]
+    const httpRequest = {
+      body: {
+        carBrandKey: carBrand.key,
+        carKey: carBrand.cars[0].key
+      }
+    }
+    const result = await sut.handle(httpRequest)
+
+    expect(result.statusCode).toBe(200)
+    expect(result.body.key).not.toBeNull()
   })
 })


### PR DESCRIPTION
This PR implements the `POST /api/prorposals`
This route should create a new Refinancing Proposal,

requires: 
``` ts
{
 carBrandKey: string
 carKey: string
}
```

returns: 
``` ts
{
 key: string /// << proposal key
}
```